### PR TITLE
feat(front, back): 학교별 학사일정 조회 기능 전국으로 변경

### DIFF
--- a/backend/controllers/schoolScheduleController.js
+++ b/backend/controllers/schoolScheduleController.js
@@ -41,3 +41,27 @@ exports.getSchedule = async (req, res) => {
         res.status(500).json({ error: "학사 일정 조회 실패" });
     }
 };
+
+exports.getAllSchedule = async (req, res) => {
+    try {
+        const { schoolId, atptCode } = req.params;
+        const { year, grade } = req.query;
+
+        if (!schoolId || !atptCode) {
+            return res.status(400).json({
+                error: "schoolId와 atptCode(교육청 코드)는 필수입니다",
+            });
+        }
+
+        const schedule = await schoolscheduleService.getAllSchoolSchedule(
+            schoolId,
+            atptCode,
+            { year, grade }
+        );
+
+        res.json(schedule);
+    } catch (err) {
+        console.error(err);
+        res.status(500).json({ error: "전국 학사 일정 조회 실패" });
+    }
+};

--- a/backend/routes/schoolScheduleRoute.js
+++ b/backend/routes/schoolScheduleRoute.js
@@ -8,4 +8,7 @@ router.get('/schools', schoolScheduleController.searchSchools);
 // 2. 학사 일정 조회 (예: /schools/7010569/schedule 또는 /schools/7010569/schedule?year=prev&grade=3)
 router.get('/schools/:schoolId/schedule', schoolScheduleController.getSchedule);
 
+// 3. 전 지역 학사일정 조회 (교육청 코드 필요)
+router.get("/schools/:schoolId/:atptCode/schedule", schoolScheduleController.getAllSchedule);
+
 module.exports = router;

--- a/backend/services/schoolScheduleService.js
+++ b/backend/services/schoolScheduleService.js
@@ -16,7 +16,7 @@ async function searchSchools(query) {
             Type: "json",
             pIndex: 1,
             pSize: 1000, // 가능한 한 많이 가져오기
-            ATPT_OFCDC_SC_CODE: "B10", // 서울특별시교육청
+            // ATPT_OFCDC_SC_CODE: "B10", // 서울특별시교육청
         };
 
         // query가 들어올 경우 학교 이름으로 필터링
@@ -37,14 +37,16 @@ async function searchSchools(query) {
                     !school.SCHUL_KND_SC_NM.includes("고등") &&
                     !school.SCHUL_KND_SC_NM.includes("각종학교(고)") &&
                     !school.SCHUL_KND_SC_NM.includes("평생학교(고)-3년6학기") &&
-                    !school.SCHUL_KND_SC_NM.includes("평생학교(고)-2년6학기") &&
-                    school.LCTN_SC_NM.includes("서울특별시")
+                    !school.SCHUL_KND_SC_NM.includes("평생학교(고)-2년6학기")
+                    // &&
+                    // school.LCTN_SC_NM.includes("서울특별시")
             )
             .map((school) => ({
                 schoolCode: school.SD_SCHUL_CODE, // 행정 표준 코드
                 name: school.SCHUL_NM, // 학교 이름
                 address: school.ORG_RDNMA, // 학교 주소
                 schoolType: school.SCHUL_KND_SC_NM, // 학교 종류 (초, 중, 고)
+                atptCode: school.ATPT_OFCDC_SC_CODE,  // 시도교육청 코드
             }));
     } catch (error) {
         console.error("학교 검색 API 호출 실패:", err);
@@ -52,7 +54,7 @@ async function searchSchools(query) {
     }
 }
 
-// 2. 학교 코드와 학년을 받아서 학사 일정 조회
+// 2. 학교 코드와 학년을 받아서 서울특별시 학사 일정 조회
 async function getSchoolSchedule(schoolCode, options = {}) {
     const today = new Date(); // 오늘 날짜
     const currentYear =
@@ -110,7 +112,66 @@ function filterByGrade(scheduleData, grade) {
     return scheduleData.filter((item) => item[key] === "Y"); // *은 미존재!?
 }
 
+// 3. 학교 코드와 학년을 받아서 전 지역 학사 일정 조회
+async function getAllSchoolSchedule(schoolCode, atptCode, options = {}) {
+    const today = new Date(); // 오늘 날짜
+    const currentYear =
+        today.getMonth() + 1 >= 3
+            ? today.getFullYear()
+            : today.getFullYear() - 1; // 올해 3월 이후면 올해, 아니면 작년
+    const year =
+        options.year === "prev"
+            ? (currentYear - 1).toString()
+            : currentYear.toString();
+    const grade = options.grade || null; // 학년 (default: null)
+
+    const url = "https://open.neis.go.kr/hub/SchoolSchedule"; // NEIS API URL
+
+    const response = await axios.get(url, {
+        params: {
+            KEY: apiKey,
+            Type: "json",
+            pIndex: 1,
+            pSize: 100,
+            ATPT_OFCDC_SC_CODE: atptCode, // 교육청 코드 (예: 서울특별시교육청 - B10)
+            SD_SCHUL_CODE: schoolCode,
+            AA_FROM_YMD: `${year}0301`, // 학사 일정 시작일 (예: year년 1월 1일)
+            AA_TO_YMD: `${parseInt(year) + 1}0228`, // 학사 일정 종료일 (예: year+1년 2월 28일)
+        },
+    });
+
+    if (!response.data.SchoolSchedule) {
+        return [];
+    }
+
+    const scheduleData = response.data.SchoolSchedule[1].row;
+
+    // 학년 필터링 요청 시 필터링해서 제공
+    return filterByGrade(scheduleData, grade);
+}
+
+function filterByGrade(scheduleData, grade) {
+    if (!grade) return scheduleData; // grade 없으면 필터링 안 함
+
+    // 학년별 키 매핑
+    const gradeKeyMap = {
+        1: "ONE_GRADE_EVENT_YN",
+        2: "TW_GRADE_EVENT_YN",
+        3: "THREE_GRADE_EVENT_YN",
+        4: "FR_GRADE_EVENT_YN",
+        5: "FIV_GRADE_EVENT_YN",
+        6: "SIX_GRADE_EVENT_YN",
+    };
+
+    const key = gradeKeyMap[grade.toString()];
+    if (!key) return scheduleData; // 잘못된 학년 입력 시 필터 안 함
+
+    // 해당 키가 "Y"인 항목만 필터링
+    return scheduleData.filter((item) => item[key] === "Y"); // *은 미존재!?
+}
+
 module.exports = {
     searchSchools,
     getSchoolSchedule,
+    getAllSchoolSchedule,
 };

--- a/frontend/src/api/schoolApi.js
+++ b/frontend/src/api/schoolApi.js
@@ -5,12 +5,12 @@ export const searchSchoolsByName = async (schoolName) => {
     return axios.get(`/schoolSchedule/schools?query=${schoolName}`);
 };
 
-// 2. 학교 ID로 올해의 전체 학사일정 조회
+// 2. 학교 ID로 올해의 전체 학사일정 조회 (서울)
 export const getSchoolSchedule = async (schoolId) => {
     return axios.get(`/schoolSchedule/schools/${schoolId}/schedule`);
 };
 
-// 3. 학교 ID로 올해의 학년별 학사일정 조회
+// 3. 학교 ID로 올해의 학년별 학사일정 조회 (서울)
 export const getSchoolScheduleByGrade = async (schoolId, grade) => {
     return axios.get(
         `/schoolSchedule/schools/${schoolId}/schedule?grade=${grade}`
@@ -22,9 +22,22 @@ export const getPrevSchoolSchedule = async (schoolId) => {
     return axios.get(`/schoolSchedule/schools/${schoolId}/schedule?year=prev`);
 };
 
-// 4. 학교 ID로 작년의 학년별 학사일정 조회
+// 5. 학교 ID로 작년의 학년별 학사일정 조회
 export const getPrevSchoolScheduleByGrade = async (schoolId, grade) => {
     return axios.get(
         `/schoolSchedule/schools/${schoolId}/schedule?year=prev&grade=${grade}`
+    );
+};
+
+// 6. 학교 ID + 교육청 코드로 전체 학사일정 조회 (서울 외 지역도 가능)
+export const getAllSchoolSchedule = async (schoolId, atptCode, year, grade) => {
+    const params = {};
+
+    if (year) params.year = year;
+    if (grade) params.grade = grade;
+
+    return axios.get(
+        `/schoolSchedule/schools/${schoolId}/${atptCode}/schedule`,
+        { params }
     );
 };


### PR DESCRIPTION
- 기존 코드는 서울특별시만 조회하도록 함
- 현재 코드는 시도교육청 코드를 가져올 수 있도록 수정하여, 전 지역 조회 가능함
- 평균 학사일정은 여전히 서울특별시만 조회 가능